### PR TITLE
TRAVIS : Error with Fasta File names in ArkasData.

### DIFF
--- a/vignettes/arkas.Rmd
+++ b/vignettes/arkas.Rmd
@@ -82,7 +82,7 @@ OutputPath<-"/data/output"
 fastqPath <- paste0(pathBase, "/fastq")
 samples <- c(MrN="MrN", MrT="MrT")
 FastaFiles <- c( "ERCC.fa", ## spike-in controls                    
-                  "Homo_sapiens.RepBase.20_05.merged.fa") #no duplicates
+                  "Homo_sapiens.RepBase.20_05.merged.fa.gz") #no duplicates
 indexName <- indexKallisto(fastaFiles=FastaFiles, fastaPath=FastaPath)$indexName
 indexName  #prints the full index Name
 Xtension<-"_*"


### PR DESCRIPTION
the fasta file default in arkasData which the vignette builds is zipp…ed, but the arkas.RMD has an unzipped name which caused problems.  this fixed it locally, pushing up to test travis.

this will most likely fix the travis build errors.  
