### PR TITLE
updating the vignettes to be html_vig not html_doc

### DIFF
--- a/vignettes/arkas.Rmd
+++ b/vignettes/arkas.Rmd
@@ -1,10 +1,14 @@
 ---
 title: "Arkas: Repetitive Elements Quantification In Much Less Time"
-author:  "Timothy J. Triche, Jr, Anthony R. Colombo, Harold Pimentel"
+author: "Timothy Triche Jr., Anthony Colombo, Harold Pimmentel"
 output: 
-    html_document:
-      toc: true
-      number_sections: true
+  html_vignette:
+  toc: true
+  number_sections: true
+vignette: >
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteIndexEntry{Arkas: Repetitive Elements Quantification In Much Less Time}
+  \usepackage[utf8]{inputenc}   
 date: "`r format(Sys.time(), '%d %B, %Y')`"
 ---
           

--- a/vignettes/crossModels.Rmd
+++ b/vignettes/crossModels.Rmd
@@ -2,11 +2,14 @@
 title: "Crossing Experiments comparitively with limma/voom versus edgeR"
 author: "Anthony R. Colombo, Tim J. Triche, Jr."
 date: "`r Sys.Date()`"
-output: rmarkdown::html_vignette
+output:
+   html_vignette:
+   toc: true
+   number_sections: true
 vignette: >
-  %\VignetteIndexEntry{Vignette Title}
+  %\VignetteIndexEntry{Crossing Experiments comparitively with limma/voom versus edgeR}
   %\VignetteEngine{knitr::rmarkdown}
-  %\VignetteEncoding{UTF-8}
+  %\VignetteEncoding[utf8]{inputenc}
 ---
 
 #Introduction

--- a/vignettes/geneWiseAnalysis.Rmd
+++ b/vignettes/geneWiseAnalysis.Rmd
@@ -2,9 +2,13 @@
 title: "Arkas: Raw Reads To Pathway Analsyes In Much Less Time"
 author:  "Timothy J. Triche, Jr, Anthony R. Colombo, Harold Pimentel"
 output: 
-    html_document:
+    html_vignette:
       toc: true
       number_sections: true
+vignette: >
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteIndexEntry{Arkas: Raw Reads To Pathway Analsyes In Much Less Time}
+  \usepackage[utf8]{inputenc}
 date: "`r format(Sys.time(), '%d %B, %Y')`"
 ---
           

--- a/vignettes/gwa-safeExit.Rmd
+++ b/vignettes/gwa-safeExit.Rmd
@@ -1,10 +1,14 @@
 ---
-title: "Arkas: Repetitive Elements Quantification In Much Less Time"
-author:  "Timothy J. Triche, Jr, Anthony R. Colombo, Harold Pimentel"
+title: "Arkas: Rapid Gene Level Analysis"
+author:  "Anthony R. Colombo, Timothy Triche Jr., Harold Pimentel"
 output: 
-    html_document:
+    html_vignette:
       toc: true 
       number_sections: true
+vignette: >
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteIndexEntry{Arkas: Rapid Gene Level Analysis}
+  \usepackage[utf8]{inputenc}
 date: "`r format(Sys.time(), '%d %B, %Y')`"
 ---
           


### PR DESCRIPTION
the travis is error a strange error from their server regarding the previous PR, so resubmitting crossModels PR patch (travis only motivations)
